### PR TITLE
feat: 찜 기능 추가

### DIFF
--- a/src/main/java/com/sparta/spartaproject/common/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/spartaproject/common/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.sparta.spartaproject.domain.user.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class SecurityConfig {
     private final JwtUtils jwtUtils;
     private final CustomUserDetailsService customUserDetailsService;

--- a/src/main/java/com/sparta/spartaproject/controller/LikeController.java
+++ b/src/main/java/com/sparta/spartaproject/controller/LikeController.java
@@ -1,0 +1,56 @@
+package com.sparta.spartaproject.controller;
+
+import com.sparta.spartaproject.domain.like.LikeService;
+import com.sparta.spartaproject.dto.request.CreateLikeRequestDto;
+import com.sparta.spartaproject.dto.response.LikeDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Description;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class LikeController {
+    private final LikeService likeService;
+
+    @Description(
+        "사용자용 - 찜 전체 조회"
+    )
+    @GetMapping("/likes")
+    @PreAuthorize("hasAnyAuthority('CUSTOMER', 'MASTER', 'MANAGER')")
+    public ResponseEntity<List<LikeDto>> getLikes() {
+        return ResponseEntity.ok(likeService.getLikes());
+    }
+
+    @Description(
+        "찜 상세 조회"
+    )
+    @GetMapping("/likes/{id}")
+    public ResponseEntity<LikeDto> getLike(@PathVariable UUID id) {
+        return ResponseEntity.ok(likeService.getLike(id));
+    }
+
+    @Description(
+        "찜 하기 - 토글 방식"
+    )
+    @PostMapping("/likes")
+    public ResponseEntity<Void> toggleLike(@RequestBody CreateLikeRequestDto request) {
+        likeService.toggleLike(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Description(
+        "찜 삭제"
+    )
+    @DeleteMapping("/likes/{id}")
+    @PreAuthorize("hasAnyAuthority('CUSTOMER', 'MASTER', 'MANAGER')")
+    public ResponseEntity<Void> deleteLike(@PathVariable UUID id) {
+        likeService.deleteLike(id);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/sparta/spartaproject/domain/category/CategoryRepository.java
+++ b/src/main/java/com/sparta/spartaproject/domain/category/CategoryRepository.java
@@ -2,11 +2,8 @@ package com.sparta.spartaproject.domain.category;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
 import java.util.UUID;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
     Boolean existsByName(String name);
-
-    Optional<Category> findById(UUID id);
 }

--- a/src/main/java/com/sparta/spartaproject/domain/like/Like.java
+++ b/src/main/java/com/sparta/spartaproject/domain/like/Like.java
@@ -1,0 +1,53 @@
+package com.sparta.spartaproject.domain.like;
+
+import com.sparta.spartaproject.domain.BaseTimeEntity;
+import com.sparta.spartaproject.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@SuperBuilder
+@DynamicInsert
+@DynamicUpdate
+@Table(name = "p_like")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    // TODO: Store 커밋되면 수정해야함
+    private UUID storeId;
+
+    @Column(
+        nullable = false,
+        columnDefinition = "Boolean default false"
+    )
+    private Boolean isDeleted;
+
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (id == null) {
+            id = UUID.randomUUID();
+        }
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/sparta/spartaproject/domain/like/LikeRepository.java
+++ b/src/main/java/com/sparta/spartaproject/domain/like/LikeRepository.java
@@ -1,0 +1,15 @@
+package com.sparta.spartaproject.domain.like;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface LikeRepository extends JpaRepository<Like, UUID> {
+    List<Like> findAllByUserIdAndIsDeletedIsFalse(Long userId);
+
+    Optional<Like> findByIdAndIsDeletedIsFalse(UUID id);
+
+    Optional<Like> findByUserIdAndStoreIdAndIsDeletedIsFalse(Long userId, UUID storeId);
+}

--- a/src/main/java/com/sparta/spartaproject/domain/like/LikeService.java
+++ b/src/main/java/com/sparta/spartaproject/domain/like/LikeService.java
@@ -1,0 +1,93 @@
+package com.sparta.spartaproject.domain.like;
+
+import com.sparta.spartaproject.domain.user.User;
+import com.sparta.spartaproject.domain.user.UserService;
+import com.sparta.spartaproject.dto.request.CreateLikeRequestDto;
+import com.sparta.spartaproject.dto.response.LikeDto;
+import com.sparta.spartaproject.exception.BusinessException;
+import com.sparta.spartaproject.mapper.LikeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.sparta.spartaproject.exception.ErrorCode.LIKE_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final UserService userService;
+    private final LikeMapper likeMapper;
+    private final LikeRepository likeRepository;
+
+    @Transactional(readOnly = true)
+    public List<LikeDto> getLikes() {
+        User user = userService.loginUser();
+
+//        if (user.getRole() != Role.CUSTOMER) {
+//            //  클라이언트가 요청을 보냈으나, 권한이 없어서 접근을 거부하는 경우
+//            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "권한이 존재하지 않습니다.");
+//        }
+
+        return likeRepository.findAllByUserIdAndIsDeletedIsFalse(user.getId()).stream().map(
+            likeMapper::toLikeDto
+        ).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public LikeDto getLike(UUID id) {
+        Like like = getLikeByIdAndIsDeletedIsFalse(id);
+
+        User user = userService.loginUser();
+        // TODO: Store 검증 코드
+
+        if (!Objects.equals(like.getUser().getId(), user.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "권한이 존재하지 않습니다.");
+        }
+
+        return likeMapper.toLikeDto(like);
+    }
+
+    @Transactional
+    public void toggleLike(CreateLikeRequestDto request) {
+        User user = userService.loginUser();
+        log.info("{}", user.getId());
+
+        // Store store = storeService.getStoreById(request.storeId());
+        Optional<Like> like = likeRepository.findByUserIdAndStoreIdAndIsDeletedIsFalse(user.getId(), request.storeId());
+
+        if (like.isPresent()) {
+            // 이미 찜한 경우
+            likeRepository.delete(like.get());
+            log.info("찜 취소");
+        } else {
+            Like newLike = likeMapper.toLike(request, user);
+            likeRepository.save(newLike);
+            log.info("찜 등록");
+        }
+    }
+
+    @Transactional
+    public void deleteLike(UUID id) {
+        Like like = likeRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(LIKE_NOT_FOUND));
+
+        like.delete();
+        log.info("찜:{}, 삭제", id);
+    }
+
+
+    public Like getLikeByIdAndIsDeletedIsFalse(UUID id) {
+        // TODO: 카테고리 에러 메시지 적용, 404
+        return likeRepository.findByIdAndIsDeletedIsFalse(id)
+            .orElseThrow(() -> new BusinessException(LIKE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sparta/spartaproject/domain/user/UserService.java
+++ b/src/main/java/com/sparta/spartaproject/domain/user/UserService.java
@@ -109,6 +109,9 @@ public class UserService {
 
         user.successLogin();
 
+        Cache cache = cacheManager.getCache("loginUser");
+        cache.put(user.getId(), user); // 캐시 저장
+
         log.info("사용자:{}, 로그인 성공", user.getId());
         return jwtUtils.generateToken(user);
     }

--- a/src/main/java/com/sparta/spartaproject/dto/request/CreateLikeRequestDto.java
+++ b/src/main/java/com/sparta/spartaproject/dto/request/CreateLikeRequestDto.java
@@ -1,0 +1,8 @@
+package com.sparta.spartaproject.dto.request;
+
+import java.util.UUID;
+
+public record CreateLikeRequestDto(
+    UUID storeId
+) {
+}

--- a/src/main/java/com/sparta/spartaproject/dto/response/LikeDto.java
+++ b/src/main/java/com/sparta/spartaproject/dto/response/LikeDto.java
@@ -1,0 +1,14 @@
+package com.sparta.spartaproject.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record LikeDto(
+    UUID id,
+    Long userId,
+    UUID storeId,
+    Boolean isDeleted,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/sparta/spartaproject/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/spartaproject/exception/ErrorCode.java
@@ -27,7 +27,9 @@ public enum ErrorCode {
 
 
     //...등
-    ;
+
+    // 찜
+    LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "Like-001", "찜 목록이 존재하지 않습니다.");
 
     private final HttpStatus status; // http 상태코드
     private final String code;//에러코드

--- a/src/main/java/com/sparta/spartaproject/mapper/LikeMapper.java
+++ b/src/main/java/com/sparta/spartaproject/mapper/LikeMapper.java
@@ -1,0 +1,18 @@
+package com.sparta.spartaproject.mapper;
+
+import com.sparta.spartaproject.domain.like.Like;
+import com.sparta.spartaproject.domain.user.User;
+import com.sparta.spartaproject.dto.request.CreateLikeRequestDto;
+import com.sparta.spartaproject.dto.response.LikeDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface LikeMapper {
+    @Mapping(target = "userId", source = "user.id")
+    LikeDto toLikeDto(Like like);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "user", source = "user")
+    Like toLike(CreateLikeRequestDto request, User user);
+}

--- a/src/main/resources/db/migration/V7__create_like.sql
+++ b/src/main/resources/db/migration/V7__create_like.sql
@@ -1,0 +1,12 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+create table dev.p_like
+(
+    id         uuid default uuid_generate_v4() constraint p_like_pk primary key,
+    user_id    bigint             not null,
+    store_id   uuid               not null,
+    is_deleted bool default false not null,
+    deleted_at timestamp,
+    created_at timestamp,
+    updated_at timestamp
+);


### PR DESCRIPTION
1. flyway
- V7__create_like.sql

2. Like
- Entity 생성
- delete 메서드 추가

3. LikeController
- Controller 생성
- 사용자용 - 찜 전체 조회, getLikes 추가
- 찜 상세 조회, getLike 추가
- 찜 하기 - 토글 방식, toggleLike 추가
- 찜 삭제, deleteLike 추가

4. LikeService
- Service 생성
- 사용자용 - 찜 전체 조회, getLikes 추가
- 찜 상세 조회, getLike 추가
- 찜 하기 - 토글 방식, toggleLike 추가
- 찜 삭제, deleteLike 추가

5. LikeRepository
- findAllByUserIdAndIsDeletedIsFalse 메서드 추가
- findByIdAndIsDeletedIsFalse 메서드 추가
- findByUserIdAndStoreIdAndIsDeletedIsFalse 메서드 추가

6. Request Dto
- CreateLikeRequestDto 추가

7. Response Dto
- LikeDto 추가

8. LikeMapper
- toLikeDto 메서드 추가
- toLike 메서드 추가

9. ErrorCode
- LIKE_NOT_FOUND 추가

10. CategoryRepository
- findById(UUID id) 삭제

11. SecurityConfig
- @EnableMethodSecurity 어노테이션 추가

12. UserService
- Login 시, cache 로직 추가